### PR TITLE
SHOULD -> MUST for use of different CIDs on different paths

### DIFF
--- a/draft-lmbdhk-quic-multipath.md
+++ b/draft-lmbdhk-quic-multipath.md
@@ -270,8 +270,9 @@ If endpoints negotiate multipath support with value 1 to use multiple
 packet number spaces, they SHOULD use ACK_MP frames
 instead of ACK frames to signal acknowledgement of 1-RTT packets on path number 0, and also 0-RTT packets as specified in {{handling-of-0-rtt-packets}}.
 
-1-RTT packets sent to different paths SHOULD carry different connection identifiers, if a non-zero
-connection ID is used.
+1-RTT packets sent to different paths MUST carry different connection identifiers, if a non-zero
+connection ID is used. If a packet is received on a new 4-tuple but with an already used connection ID,
+the sender has migrated to that address and the receiver reacts as specfied in Section 9.3 in {{QUIC-TRANSPORT}}.
 
 ## Handling of 0-RTT Packets
 


### PR DESCRIPTION
There is a SHOULD here, which I believe should be a MUST as we taking about the receiver behaviour here.