### PR TITLE
Replace single instance of uniflow per path

### DIFF
--- a/draft-lmbdhk-quic-multipath.md
+++ b/draft-lmbdhk-quic-multipath.md
@@ -249,7 +249,7 @@ Multipath TCP uses the LIA congestion control scheme specified in {{RFC6356}}.  
 
 # Packet Scheduling
 
-The simultaneous usage of several sending uniflows introduces new
+The simultaneous usage of several sending paths introduces new
    algorithms (packet scheduling, path management) whose specifications
    are out of scope of this document.  Nevertheless, these algorithms
    are actually present in any multipath-enabled transport protocol like


### PR DESCRIPTION
This is really a minor issue, but the word "uniflow" appears just once in the draft, in section 5, packet scheduling. I think the packet scheduling text could simply use the word "path".