### PR TITLE
Do not assume real time formatting of server TP

### DIFF
--- a/draft-lmbdhk-quic-multipath.md
+++ b/draft-lmbdhk-quic-multipath.md
@@ -196,20 +196,27 @@ defined as follow:
 - value: 0 (default) for disabled.
 
 Endpoints use 2-bits in the value field for negotiating one or more
-PN spaces, available option value for client and server are listed in
+PN spaces, available option values are listed in
 {{param_value_definition}} :
 
-Client Option| Definition                                  | Allowed server responses
----------|-------------------------------------------------|--------------------------
-0x0      | don't support multipath                         | 0x0
-0x1      | only support one PN space for multipath         | 0x0 or 0x1
-0x2      | only support multiple PN spaces for multipath   | 0x0 or 0x2
-0x3      | support both one PN space and multiple PN space | 0x0, 0x1 or 0x2
+Option | Definition
+---------|---------------------------------------
+0x0      | don't support multipath
+0x1      | only support one PN space for multipath
+0x2      | only support multiple PN spaces for multipath
+0x3      | support both one PN space and multiple PN space
 {: #param_value_definition title="Available value for enable_multipath"}
 
-If the parameter is absent or set to 0, the endpoints MUST fallback to
+If for anyone of the endpoints the parameter is absent or set to 0,
+or if the two enpoints select incompatible values,
+one proposing 0x1 and the other proposing 0x2,
+the endpoints MUST fallback to
 {{QUIC-TRANSPORT}} with single path and MUST NOT use any frame or
 mechanism defined in this document.
+
+If an endpoint proposes the value 0x3, the value proposed by the
+other is accepted. If both endpoints propose the value 0x3, the
+value 0x2 is negotiated.
 
 If endpoint receives unexpected value for the transport parameter
 "enable_multipath", it MUST treat this as a connection error of type

--- a/draft-lmbdhk-quic-multipath.md
+++ b/draft-lmbdhk-quic-multipath.md
@@ -207,8 +207,8 @@ Option | Definition
 0x3      | support both one PN space and multiple PN space
 {: #param_value_definition title="Available value for enable_multipath"}
 
-If for anyone of the endpoints the parameter is absent or set to 0,
-or if the two enpoints select incompatible values,
+If for any one of the endpoints the parameter is absent or set to 0,
+or if the two endpoints select incompatible values,
 one proposing 0x1 and the other proposing 0x2,
 the endpoints MUST fallback to
 {{QUIC-TRANSPORT}} with single path and MUST NOT use any frame or


### PR DESCRIPTION
The current text assumes that the server transport parameters are composed after seeing the client's proposal. As pointed out in issue #75, this is a deviation from standard QUIC practice. The proposed text fixes that and specifies what happens if both endpoints select option 3, "support both". In that case, option 2 "multiple number spaces" is selected.

Close #75